### PR TITLE
Health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ allowPathMatching | false | When updating an existing api mapping this will matc
 | route53Params:<br/>&nbsp; routingPolicy | simple | Defines the Route 53 routing policy, accepts `simple`, `latency` or `weighted`. |
 | route53Params:<br/>&nbsp; weight | `200` | Sets the weight for weighted routing. Ignored for `simple` and `latency` routing. |
 | route53Params:<br/>&nbsp; setIdentifier |  | A unique identifier for records in a set of Route 53 records with the same domain name. Only relevant for `latency` and `weighted` routing. Defaults to the regional endpoint if not provided. |
-| route53Params:<br/>&nbsp; evaluateTargetHealth | `false` | If `true`, Route 53 will check the connectivity to the endpoint. If it is unavailable, it will stop routing to it. |
+| route53Params:<br/>&nbsp; healthCheckId |  | An id for a Route 53 health check. If it is failing, Route 53 will stop routing to it. Only relevant for `latency` and `weighted` routing |
 
 
 ## Running

--- a/src/domain-config.ts
+++ b/src/domain-config.ts
@@ -104,7 +104,7 @@ class DomainConfig {
             routingPolicy: routingPolicyToUse,
             setIdentifier: config.route53Params?.setIdentifier,
             weight: config.route53Params?.weight ?? 200,
-            evaluateTargetHealth: config.route53Params?.evaluateTargetHealth ?? false
+            healthCheckId: config.route53Params?.healthCheckId
         }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -431,17 +431,23 @@ class ServerlessCustomDomain {
         // Set up parameters
         const route53HostedZoneId = await this.getRoute53HostedZoneId(domain);
 
+        const healthCheckConfig = domain.route53Params.healthCheckId
+            ? { HealthCheckId: domain.route53Params.healthCheckId }
+            : {};
+
         const latencyRecordConfig = domain.route53Params.routingPolicy === "latency"
             ? {
                 Region: domain.region,
-                SetIdentifier: domain.route53Params.setIdentifier ?? domain.domainInfo.domainName
+                SetIdentifier: domain.route53Params.setIdentifier ?? domain.domainInfo.domainName,
+                ...healthCheckConfig,
             }
             : {};
 
         const weightedRecordConfig = domain.route53Params.routingPolicy === "weighted"
             ? {
                 Weight: domain.route53Params.weight,
-                SetIdentifier: domain.route53Params.setIdentifier ?? domain.domainInfo.domainName
+                SetIdentifier: domain.route53Params.setIdentifier ?? domain.domainInfo.domainName,
+                ...healthCheckConfig,
             }
             : {};
 
@@ -450,13 +456,13 @@ class ServerlessCustomDomain {
             ResourceRecordSet: {
                 AliasTarget: {
                     DNSName: domain.domainInfo.domainName,
-                    EvaluateTargetHealth: domain.route53Params.evaluateTargetHealth,
+                    EvaluateTargetHealth: false,
                     HostedZoneId: domain.domainInfo.hostedZoneId,
                 },
                 Name: domain.givenDomainName,
                 Type,
                 ...latencyRecordConfig,
-                ...weightedRecordConfig
+                ...weightedRecordConfig,
             },
         }));
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,5 +66,5 @@ export interface Route53Params {
     routingPolicy: 'simple' | 'latency' | 'weighted' | undefined;
     weight: number | undefined;
     setIdentifier: string | undefined;
-    evaluateTargetHealth: boolean | undefined;
+    healthCheckId: string | undefined;
 };

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -1928,7 +1928,7 @@ describe("Custom Domain Plugin", () => {
                                 Name: "test_domain",
                                 Type: "A",
                                 Region: "eu-west-1",
-                                SetIdentifier: "test_regional_name"
+                                SetIdentifier: "test_regional_name",
                             },
                         },
                         {
@@ -1942,7 +1942,7 @@ describe("Custom Domain Plugin", () => {
                                 Name: "test_domain",
                                 Type: "AAAA",
                                 Region: "eu-west-1",
-                                SetIdentifier: "test_regional_name"
+                                SetIdentifier: "test_regional_name",
                             },
                         },
                     ],
@@ -1974,7 +1974,8 @@ describe("Custom Domain Plugin", () => {
                 endpointType: "regional",
                 route53Params: {
                     routingPolicy: 'weighted',
-                    weight: 100
+                    weight: 100,
+                    healthCheckId: "test_healthcheck",
                 }
             });
             plugin.route53 = new aws.Route53();
@@ -2006,7 +2007,8 @@ describe("Custom Domain Plugin", () => {
                                 Name: "test_domain",
                                 Type: "A",
                                 SetIdentifier: "test_regional_name",
-                                Weight: 100
+                                Weight: 100,
+                                HealthCheckId: "test_healthcheck",
                             },
                         },
                         {
@@ -2020,7 +2022,8 @@ describe("Custom Domain Plugin", () => {
                                 Name: "test_domain",
                                 Type: "AAAA",
                                 SetIdentifier: "test_regional_name",
-                                Weight: 100
+                                Weight: 100,
+                                HealthCheckId: "test_healthcheck",
                             },
                         },
                     ],
@@ -2052,7 +2055,7 @@ describe("Custom Domain Plugin", () => {
                 endpointType: "regional",
                 route53Params: {
                     routingPolicy: 'latency',
-                    weight: 100
+                    weight: 100,
                 }
             });
             plugin.route53 = new aws.Route53();
@@ -2130,7 +2133,7 @@ describe("Custom Domain Plugin", () => {
                 endpointType: "regional",
                 route53Params: {
                     setIdentifier: "test_identifier",
-                    weight: 100
+                    weight: 100,
                 }
             });
             plugin.route53 = new aws.Route53();

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -2109,7 +2109,7 @@ describe("Custom Domain Plugin", () => {
             expect(spy).to.have.been.called.with(expectedParams);
         });
 
-        it("Should exclude weight, region, and set identifier input with simple routing", async () => {
+        it("Should exclude weight, region, set identifier, and health input with simple routing", async () => {
             AWS.mock("Route53", "listHostedZones", (params, callback) => {
                 callback(null, {
                     HostedZones: [{


### PR DESCRIPTION
It looks like `evaluateTargetHealth` doesn't do anything for api gateway fronted lambdas. Remove that in favor of allowing users to pass a `healthCheckId`.